### PR TITLE
Feature/worship database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # prepare-submissions-for-export-service
-Microservice that listens to the delta notifier and prepares sent submissions for export
+Microservice that listens to the delta notifier and marks a resource for export if it passed the config & export requirements.
+
+```
+?resource <http://schema.org/publication> <${PUBLICATION_CONCEPT}>.
+```
 
 ## Installation
 Add the following snippet to your `docker-compose.yml`:
@@ -7,6 +11,9 @@ Add the following snippet to your `docker-compose.yml`:
 ```yml
 prepare-submissions-for-export:
   image: lblod/prepare-submissions-for-export-service
+
+  environment:
+    PUBLICATION_CONCEPT: 'http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325' //public-database 
   volumes:
     - ./config/delta-producer/submissions/prepare/:/config
 ```
@@ -17,14 +24,7 @@ Configure the delta-notification service to send notifications on the `/delta` e
 export default [
   {
     match: {
-      predicate: {
-        type: 'uri',
-        value: 'http://www.w3.org/ns/adms#status'
-      },
-      object: {
-        type: 'uri',
-        value: 'http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c' // Sent
-      }
+      //anything
     },
     callback: {
       url: 'http://prepare-submissions-for-export/delta',
@@ -39,6 +39,60 @@ export default [
   }
 ]
 ```
+
+## Config & export files
+### Config.json
+When a delta is received, this service will fetch data related to the resource. The config file is used to help determin which resource should be exported. You can filter on *decisionTypes*, *orgaan & eenheid* and *regulationTypes*. 
+
+example:
+```
+{
+  "decisionTypes": [
+    "https://data.vlaanderen.be/id/concept/BesluitType/a0a709a7-ac07-4457-8d40-de4aea9b1432", // jaarrekening AGB
+  ],
+  "besluitenlijstOptions": [
+    {
+      "orgaan": "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005", // Gemeenteraad
+      "eenheid": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001" // Gemeente
+    },
+  ],
+}
+
+```
+Whith this config, only resources that have decision type *Advies bij jaarrekening AGB* and are send in by a Gemeenteraads orgaan en gemeente eenheid will be marked for export.
+
+### Export.json 
+In the export.json file you specify which type should be exported. Following example will export resources with that are of type `meb:Submission`
+
+```
+{
+  "export": [
+    {
+      "type": "http://rdf.myexperiment.org/ontologies/base/Submission"
+    },
+ ]
+}
+```
+
+Additionally, you can add more types and the path to the submission document. 
+```
+{
+  "export": [
+    {
+      "type": "http://rdf.myexperiment.org/ontologies/base/Submission"
+    },
+    {
+      "type": "http://mu.semte.ch/vocabularies/ext/SubmissionDocument",
+      "pathToSubmission": "?submission <http://purl.org/dc/terms/subject> ?subject; \n a <http://rdf.myexperiment.org/ontologies/base/Submission>."
+    },
+ ]
+}
+```
+
+## Environment variable
+| ENV  | Description | default | required |
+|---|---|---|---|
+| PUBLICATION_CONCEPT | URI used to flag a publication for export. | | yes |
 
 ## API
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+export const PUBLICATION_CONCEPT = process.env.PUBLICATION_CONCEPT;
+
+if (!PUBLICATION_CONCEPT) {
+  throw 'PUBLICATION_CONCEPT environment variable cannot be undefined'
+}

--- a/util/queries.js
+++ b/util/queries.js
@@ -147,7 +147,7 @@ export async function flagResource(uri) {
     INSERT {
       GRAPH ?g {
         ${sparqlEscapeUri(uri)}
-          schema:publication <http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325> .
+          schema:publication ${sparqlEscapeUri(PUBLICATION_CONCEPT)} .
       }
     } WHERE {
       GRAPH ?g {

--- a/util/queries.js
+++ b/util/queries.js
@@ -1,8 +1,8 @@
 import { uuid, sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime } from "mu";
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
+import { PUBLICATION_CONCEPT } from "../config";
 
 const CREATOR = 'http://lblod.data.gift/services/prepare-submissions-for-export-service';
-const PUBLIC_DECISIONS_PUBLICATION_CONCEPT = 'http://lblod.data.gift/concepts/83f7b480-fcaf-4795-b603-7f3bce489325';
 
 export async function getResourceInfo(uri) {
   const result = await query(`
@@ -16,7 +16,7 @@ export async function getResourceInfo(uri) {
       }
       FILTER NOT EXISTS {
         GRAPH ?g {
-          ?resource <http://schema.org/publication> ${sparqlEscapeUri(PUBLIC_DECISIONS_PUBLICATION_CONCEPT)}.
+          ?resource <http://schema.org/publication> ${sparqlEscapeUri(PUBLICATION_CONCEPT)}.
         }
       }
       FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))
@@ -54,7 +54,7 @@ export async function getUnpublishedSubjectsFromSubmission(submission, type, pat
       ${pathToSubmission}
 
       FILTER NOT EXISTS {
-        ?subject <http://schema.org/publication> ${sparqlEscapeUri(PUBLIC_DECISIONS_PUBLICATION_CONCEPT)}.
+        ?subject <http://schema.org/publication> ${sparqlEscapeUri(PUBLICATION_CONCEPT)}.
       }
 
       FILTER(?g NOT IN (<http://redpencil.data.gift/id/deltas/producer/loket-submissions>))


### PR DESCRIPTION
Going with a duplicate prepare-submissions service in digitaal-loket. Tried changing the service to add multiple flags based on different configs but complexity increases a lot and timing issues might occur. Instead, just updating this service to use a PUBLICATION_CONCEPT env variable does the trick

Related PR: 
https://github.com/lblod/app-digitaal-loket/pull/224