### PR TITLE
Adding new worship submissions flag for "Melding onvolledigheid inzending eredienstbestuur" and "Opstart beroepsprocedure naar aanleiding van een beslissing"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prepare-submissions-for-export-service",
-  "version": "0.7.0",
+  "version": "0.8.0-rc.1",
   "description": "Microservice to prepares submitted submissions for exporting.",
   "repository": {
     "type": "git",

--- a/rules.js
+++ b/rules.js
@@ -269,6 +269,8 @@ const worshipDecisionTypes = [
   "https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29", // Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie (CB)
   "https://data.vlaanderen.be/id/concept/BesluitType/d85218e2-a75f-4a30-9182-512b5c9dd1b2", // Budget(wijziging) - Indiening bij toezichthoudende gemeente of provincie (EB)
   "https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b", // Budget(wijziging) - Indiening bij centraal bestuur of representatief orgaan (EB)
+  "https://data.vlaanderen.be/id/concept/BesluitDocumentType/863caf68-97c9-4ee0-adb5-620577ea8146", // Melding onvolledigheid inzending eredienstbestuur (GO/PO)
+  "https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae" // Opstart beroepsprocedure naar aanleiding van een beslissing (GO/PO/EB/CB)
 ];
 
 for (const worshipDecisionType of worshipDecisionTypes) {
@@ -313,6 +315,7 @@ const representativeOrgansSubmissionTypes = [
   "https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777", // Naamswijziging (RO)
   "https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b", // Wijziging gebiedsomschrijving (RO)
   "https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e", // Opheffing van annexe kerken en kapelanijen (RO)
+  "https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae"  // Opstart beroepsprocedure naar aanleiding van een beslissing (RO)
 ];
 
 for (const submissionType of representativeOrgansSubmissionTypes) {


### PR DESCRIPTION
# Description

DL-5643 - DL-5646

This PR adds worship flag for "Melding onvolledigheid inzending eredienstbestuur" and "Opstart beroepsprocedure naar aanleiding van een beslissing" submissions.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Create these submissions in Loket
2. With the new submission UUID you should be able to see in the database if the WORSHIP_FLAG is attached to the submission
 
# What to check

- N/A

# Links to other PR's

- Manage-submissions-form-tooling -> https://github.com/lblod/manage-submission-form-tooling/pull/44
- App-digitaal-loket -> https://github.com/lblod/app-digitaal-loket/pull/528
- App-meldingsplichtige -> https://github.com/lblod/app-meldingsplichtige-api/pull/41
- App-toezicht-ABB -> https://github.com/lblod/app-toezicht-abb/pull/38
- App-public-decisions-database -> https://github.com/lblod/app-public-decisions-database/pull/25
- App-worship-decisions-database -> https://github.com/lblod/app-worship-decisions-database/pull/59
- Worship-submissions-graph-dispatcher-service -> https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/18
- Enrich-submission-service -> https://github.com/lblod/enrich-submission-service/pull/18

# Notes

Release + Bump on Loket