### PR TITLE
extend export config so export article

### DIFF
--- a/exportConfig.js
+++ b/exportConfig.js
@@ -11,6 +11,13 @@ export default [
                         a <http://rdf.myexperiment.org/ontologies/base/Submission>.`
   },
   {
+    type: `http://data.vlaanderen.be/ns/besluit#Artikel`,
+    pathToSubmission: `?submission <http://purl.org/dc/terms/subject> ?decision;
+                        a <http://rdf.myexperiment.org/ontologies/base/Submission>.
+                        ?decision <http://data.europa.eu/eli/ontology#has_part> ?subject.
+                       `
+  },
+  {
     type: `http://lblod.data.gift/vocabularies/besluit/TaxRate`,
     pathToSubmission: `?submission <http://www.w3.org/ns/prov#generated> ?formData;
                          a <http://rdf.myexperiment.org/ontologies/base/Submission>.


### PR DESCRIPTION
This PR (fixing DL-5869), will prepare `besluit:Artikel` for export, if it matches the decistion type for export.
I would suggest a code review, and test it once a first implementation is ready of DL-5866.

How to test?
Create and send a submission, as a gemeente and type "advies bij jaarrekening eredienstbestuur"
Eventually something similar as the following should happen.

```
<http://article/1>
    rdf:type	<http://data.vlaanderen.be/ns/besluit#Artikel> ;
    <http://schema.org/publication>	<http://lblod.data.gift/concepts/403b71bd-5ab9-4c92-8990-4bb19d5469d1> ; # this is the added triple!
    <http://data.europa.eu/eli/ontology#refers_to>	<http://bar/1> , <http://bar/2> ;
    <http://data.europa.eu/eli/ontology#type_document>	<http://foo/1> .
```
