### PR TITLE
Handle multiple decision types in submissions

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,13 +71,13 @@ async function processSubmission(submissionInfo) {
 
     if(publicationFlags.length) {
       //start the export (i.e. flagging) submission and related resources
-      let unexportedRelatedSubjects = [ submissionInfo.submission.value ];
+      let unexportedRelatedSubjects = [ submissionInfo.submission ];
 
       // Note: the reason why we have to flag all related resources is because the
       // publication graph maintainer is currently too stupid to do this.
       for (const config of exportConfig) {
         const subjects = await getRelatedSubjectsForSubmission(
-          submissionInfo.submission.value,
+          submissionInfo.submission,
           config.type,
           config.pathToSubmission
         );
@@ -98,7 +98,7 @@ async function processSubmission(submissionInfo) {
 }
 
 function getExportingRules(submissionInfo) {
-  return rules.filter(rule => rule.documentType == submissionInfo.decisionType.value);
+  return rules.filter(rule => submissionInfo.decisionTypes.includes(rule.documentType));
 }
 
 async function getPublicationFlags(submissionInfo, exportingRules) {
@@ -119,7 +119,7 @@ async function getPublicationFlags(submissionInfo, exportingRules) {
 
   for(const flag of Object.keys(groupedRules)) {
     for(const rule of groupedRules[flag]) {
-      const result = await querySudo(rule.matchQuery(submissionInfo.formData.value));
+      const result = await querySudo(rule.matchQuery(submissionInfo.formData));
       if(result.results.bindings.length) {
         publicationFlags.push(flag);
         break;

--- a/util/queries.js
+++ b/util/queries.js
@@ -55,7 +55,12 @@ export async function getSubmissionInfoForFormData(formData) {
     }`);
 
   if (result.results.bindings.length) {
-    return result.results.bindings[0];
+    // We can receive a submission with multiple decision types that all need to be evaluated
+    return {
+      submission: result.results.bindings[0].submission.value,
+      formData: result.results.bindings[0].formData.value,
+      decisionTypes: result.results.bindings.map(res => res.decisionType.value)
+    };
   } else {
     console.log(`Submission info not found.`);
     return null;
@@ -104,7 +109,12 @@ export async function getSubmissionInforForRemoteDataObject(remoteDataObject) {
 
   if (result.results.bindings.length) {
     console.log(`Found late RemoteDataObject coming in later ${remoteDataObject}`);
-    return result.results.bindings[0];
+    // We can receive a submission with multiple decision types that all need to be evaluated
+    return {
+      submission: result.results.bindings[0].submission.value,
+      formData: result.results.bindings[0].formData.value,
+      decisionTypes: result.results.bindings.map(res => res.decisionType.value)
+    };
   } else {
     console.log(`Submission info not found.`);
     return null;


### PR DESCRIPTION
# Issue

Some submissions submitted by vendors have multiple types, and in that list of types sometimes one is defined in the rules and the other not. When it arrives in the `prepare-submissions-for-export-service`, only the first-found type is evaluated and if, bad luck that one is not in the rules, the submission isn't flagged at all to be exported.

# Solution

Make the service more resilient to check all the decision types in the rules for a match.

# Relates to
- The story  [DL-6182]
- The script to fix the data in [loket](https://github.com/lblod/app-digitaal-loket/pull/599)